### PR TITLE
bump nodejs from 12 to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     default: -1
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'
 branding:
   icon: 'alert-triangle'


### PR DESCRIPTION
> "Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: deepakputhraya/action-branch-name"

The following warning showed up in my CI annotation


fixes #12 